### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: CodeQL
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/arvato-systems-jacs/bonaparte-java/security/code-scanning/2](https://github.com/arvato-systems-jacs/bonaparte-java/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the root of the workflow file. This block will explicitly define the least privileges required for the workflow to function correctly. Since the workflow uses a reusable workflow, we should ensure that the permissions granted are minimal and appropriate for the tasks performed by the reusable workflow.

The recommended permissions are:
- `contents: read` to allow the workflow to read repository contents.
- Additional permissions (e.g., `pull-requests: write`) should only be added if required by the reusable workflow.

The `permissions` block should be added at the root level of the workflow file, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
